### PR TITLE
Adds program_graph.proto to represent symbol table

### DIFF
--- a/data/example_graph.textproto
+++ b/data/example_graph.textproto
@@ -1,0 +1,34 @@
+# proto:program_graph.proto
+
+# A program is modelled as a graph.
+#
+# def fib(n):
+#   if n < 2:
+#     return n
+#   return fib(n-1) + fib(n-2)
+#
+# my_error = "Oh no! Over 1000."
+#
+# def do_fib(n):
+#   if n >= 1000:
+#     return my_error
+#   return fib(n)
+#
+
+symbol: {
+    name: "fib"
+    kind: SYMBOL
+    u_edge: "fib"
+}
+
+symbol: {
+    name: "my_error"
+    kind: SYMBOL
+}
+
+symbol: {
+    name: "do_fib"
+    kind: SYMBOL
+    u_edge: "my_error" 
+    u_edge: "fib" 
+}

--- a/program_graph.proto
+++ b/program_graph.proto
@@ -1,0 +1,29 @@
+syntax = "proto3";
+
+// NodeDef represents a node within the program graph.
+//
+// This can be be a file, BUILD target, or AST symbol. Note there is not enough
+// information to split the program yet. Multi-file symbols are unsupported.
+message NodeDef {
+    // Unique name within the context of a single program.
+    optional string name = 1;
+
+    enum Kind {
+        UNKNOWN = 0;
+        FILE = 1;
+        BUILD_TARGET = 2;
+        SYMBOL = 3;
+    }
+
+    // The type of node. Is this a file or a AST symbol (e.g. function)?
+    optional Kind kind = 2;
+
+    // Name of out-edge symbols. For a program to be considered valid, all
+    // symbolic references must be present in the graph.
+    repeated string u_edge = 3;
+}
+
+// GraphDef represents a high-level program graph.
+message GraphDef {
+    repeated NodeDef symbol = 1;
+}


### PR DESCRIPTION
These protos will be used to store symbols within a program. A GraphDef stores a symbol table which keeps track of forward references. There is enough data here to successfully split a program at the file level or symbolic level.