### PR TITLE
Adds splitbrain V2 (generalised) algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+*.pyc

--- a/main.py
+++ b/main.py
@@ -10,4 +10,4 @@ TODO(cambr): Implement.
 """
 
 if __name__ == '__main__':
-    raise NotImplementedError("Not yet implemented - see splitbrain.py.")
+  raise NotImplementedError("Not yet implemented - see splitbrain.py.")

--- a/main.py
+++ b/main.py
@@ -1,0 +1,13 @@
+"""Entry-point for SplitBrain inference.
+
+Reads in a program graph and generates output symbols. See splitbrain.py for
+the algorithm itself.
+
+Usage:
+  ./splitbrain.py --input_graph=example_graph.textproto --output_dir=out
+
+TODO(cambr): Implement.
+"""
+
+if __name__ == '__main__':
+    raise NotImplementedError("Not yet implemented - see splitbrain.py.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+networkx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 networkx
 absl-py
+protobuf

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 networkx
+absl-py

--- a/splitbrain.py
+++ b/splitbrain.py
@@ -1,5 +1,8 @@
 """Naive implementation of the generalised (V2) SplitBrain algorithm.
 
+Computes the set of all possible commits from a symbol-graph. When squashed,
+sub-commits should be equal to the orignal commit.
+
 V1 (internal) was based upon file-level splits, operating against Bazel's BUILD
 target graph. V2 (open-source) is a generalised graph search which iteratively
 finds and extracts leaf nodes from a graph.

--- a/splitbrain.py
+++ b/splitbrain.py
@@ -15,43 +15,21 @@ See main.py for running the algorithm against input data.
 
 import networkx as nx
 
-# A program is modelled as a graph.
-#
-# def fib(n):
-#   if n < 2:
-#     return n
-#   return fib(n-1) + fib(n-2)
-#
-# my_error = "Oh no! Over 1000."
-#
-# def do_fib(n):
-#   if n >= 1000:
-#     return my_error
-#   return fib(n)
-#
-G = nx.DiGraph()
-G.add_nodes_from(["fib", "my_error", "do_fib"])
-G.add_edge("fib", "fib")  # self loops.
-G.add_edge("do_fib", "my_error")
-G.add_edge("do_fib", "fib")
-G.remove_edges_from(nx.selfloop_edges(G))
+def compute_sub_cls(G):
+  # Next, find leaf nodes of the program symbols. Iteratively remove them
+  # from the graph until at the final state.
+  def _find_leaf_nodes(graph):
+    return [v for v, d in graph.out_degree() if d == 0]
 
-# Next, find leaf nodes of the program symbols. Iteratively remove them
-# from the graph until at the final state.
-def find_leaf_nodes(graph):
-  return [v for v, d in graph.out_degree() if d == 0]
+  CLs = []
 
-CLs = []
+  while len(G) > 0:
+    symbols = []
+    leaves = _find_leaf_nodes(G)
+    for leaf in leaves:
+      G.remove_node(leaf)
+      symbols.append(leaf)
 
-while len(G) > 0:
-  symbols = []
-  leaves = find_leaf_nodes(G)
-  for leaf in leaves:
-    G.remove_node(leaf)
-    symbols.append(leaf)
+    CLs.append(symbols)
 
-  CLs.append(symbols)
-
-# Finally, print the CLs.
-for changelist in CLs:
-  print('Changelist: ' + str(changelist))
+  return CLs

--- a/splitbrain.py
+++ b/splitbrain.py
@@ -1,0 +1,55 @@
+"""Naive implementation of the generalised (V2) SplitBrain algorithm.
+
+V1 (internal) was based upon file-level splits, operating against Bazel's BUILD
+target graph. V2 (open-source) is a generalised graph search which iteratively
+finds and extracts leaf nodes from a graph.
+
+Vertices/edges in the V2 graph are abstract, and can represent files/imports,
+symbols/calls or targets/srcs. 
+
+Usage:
+  ./splitbrain.py --input_graph=example_graph.textproto --output_dir=out
+"""
+
+import networkx as nx
+
+# A program is modelled as a graph.
+#
+# def fib(n):
+#   if n < 2:
+#     return n
+#   return fib(n-1) + fib(n-2)
+#
+# my_error = "Oh no! Over 1000."
+#
+# def do_fib(n):
+#   if n >= 1000:
+#     return my_error
+#   return fib(n)
+#
+G = nx.DiGraph()
+G.add_nodes_from(["fib", "my_error", "do_fib"])
+G.add_edge("fib", "fib")  # self loops.
+G.add_edge("do_fib", "my_error")
+G.add_edge("do_fib", "fib")
+G.remove_edges_from(nx.selfloop_edges(G))
+
+# Next, find leaf nodes of the program symbols. Iteratively remove them
+# from the graph until at the final state.
+def find_leaf_nodes(graph):
+  return [v for v, d in graph.out_degree() if d == 0]
+
+CLs = []
+
+while len(G) > 0:
+  symbols = []
+  leaves = find_leaf_nodes(G)
+  for leaf in leaves:
+    G.remove_node(leaf)
+    symbols.append(leaf)
+
+  CLs.append(symbols)
+
+# Finally, print the CLs.
+for changelist in CLs:
+  print('Changelist: ' + str(changelist))

--- a/splitbrain.py
+++ b/splitbrain.py
@@ -1,17 +1,16 @@
 """Naive implementation of the generalised (V2) SplitBrain algorithm.
 
 Computes the set of all possible commits from a symbol-graph. When squashed,
-sub-commits should be equal to the orignal commit.
+sub-commits should be equal to the original commit.
 
 V1 (internal) was based upon file-level splits, operating against Bazel's BUILD
 target graph. V2 (open-source) is a generalised graph search which iteratively
 finds and extracts leaf nodes from a graph.
 
 Vertices/edges in the V2 graph are abstract, and can represent files/imports,
-symbols/calls or targets/srcs. 
+symbols/calls or targets/srcs.
 
-Usage:
-  ./splitbrain.py --input_graph=example_graph.textproto --output_dir=out
+See main.py for running the algorithm against input data.
 """
 
 import networkx as nx

--- a/splitbrain_test.py
+++ b/splitbrain_test.py
@@ -1,0 +1,36 @@
+import networkx as nx
+from absl.testing import absltest
+import splitbrain
+
+class SplitbrainTest(absltest.TestCase):
+  def test_fib(self):
+    # A program is modelled as a graph.
+    #
+    # def fib(n):
+    #   if n < 2:
+    #     return n
+    #   return fib(n-1) + fib(n-2)
+    #
+    # my_error = "Oh no! Over 1000."
+    #
+    # def do_fib(n):
+    #   if n >= 1000:
+    #     return my_error
+    #   return fib(n)
+    #
+    G = nx.DiGraph()
+    G.add_nodes_from(["fib", "my_error", "do_fib"])
+    G.add_edge("fib", "fib")  # self loops.
+    G.add_edge("do_fib", "my_error")
+    G.add_edge("do_fib", "fib")
+    G.remove_edges_from(nx.selfloop_edges(G))
+
+    CLs = splitbrain.compute_sub_cls(G)
+
+    self.assertEqual(CLs, [['fib', 'my_error'], ['do_fib']])
+
+    for changelist in CLs:
+      print('Changelist: ' + str(changelist))
+
+if __name__ == '__main__':
+    absltest.main()


### PR DESCRIPTION
Naive implementation of the generalised (V2) SplitBrain algorithm.

Computes the set of all possible commits from a symbol-graph. When squashed,
sub-commits should be equal to the original commit.

V1 (internal) was based upon file-level splits, operating against Bazel's BUILD
target graph. V2 (open-source) is a generalised graph search which iteratively
finds and extracts leaf nodes from a graph.

Vertices/edges in the V2 graph are abstract, and can represent files/imports,
symbols/calls or targets/srcs. 

Usage:
  `./splitbrain.py --input_graph=example_graph.textproto --output_dir=out`