### PR TITLE
Adds launcher binary for running over arbitrary inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 *.pyc
+*_pb2.py
+.vscode

--- a/main.py
+++ b/main.py
@@ -4,9 +4,7 @@ Reads in a program graph and generates output symbols. See splitbrain.py for
 the algorithm itself.
 
 Usage:
-  ./splitbrain.py --input_graph=example_graph.textproto --output_dir=out
-
-TODO(cambr): Implement.
+  ./splitbrain.py --input_graph=example_graph.textproto
 """
 
 import os

--- a/main.py
+++ b/main.py
@@ -31,16 +31,13 @@ def _load_graphdef_from_file(path: str) -> program_graph_pb2.GraphDef:
 
 def _make_graph_from_proto(graphdef: program_graph_pb2.GraphDef) -> nx.Graph:
   graph = nx.DiGraph()
-
   graph.add_nodes_from([symbol.name for symbol in graphdef.symbol])
 
   for symbol in graphdef.symbol:
     for edge in symbol.u_edge:
       graph.add_edge(symbol.name, edge)
 
-
   graph.remove_edges_from(nx.selfloop_edges(graph))
-
   return graph 
 
 

--- a/main.py
+++ b/main.py
@@ -9,5 +9,44 @@ Usage:
 TODO(cambr): Implement.
 """
 
+import os
+import networkx
+import splitbrain
+
+from absl import app
+from absl import flags
+from google.protobuf import text_format
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string('input_path', None, 'Path to input GraphDef.')
+flags.mark_flag_as_required('input_path')
+
+
+def _load_graphdef_from_file(path: str) -> str:
+  graphdef = {}
+  with open(path, 'r') as f:
+    text_format.Merge(f.read(), graphdef)
+  return "" 
+
+
+def _make_graphdef_from_proto(proto: dict) -> networkx.Graph:
+  return None
+
+
+def main(argv):
+  del argv
+
+  if not os.path.exists(FLAGS.input_path):
+    raise flags.FlagError("input path of %s is invalid".format(FLAGS.input_path))
+  graphdef = _load_graphdef_from_file(FLAGS.input_path)
+  graph = _make_graphdef_from_proto(graphdef)
+
+  CLs = splitbrain.compute_sub_cls(graph)
+
+  for changelist in CLs:
+    print('Changelist: ' + str(changelist))
+
+
 if __name__ == '__main__':
-  raise NotImplementedError("Not yet implemented - see splitbrain.py.")
+  app.run(main)

--- a/program_graph.proto
+++ b/program_graph.proto
@@ -8,7 +8,7 @@ package splitbrain;
 // information to split the program yet. Multi-file symbols are unsupported.
 message NodeDef {
     // Unique name within the context of a single program.
-    optional string name = 1;
+    string name = 1;
 
     enum Kind {
         UNKNOWN = 0;
@@ -18,7 +18,7 @@ message NodeDef {
     }
 
     // The type of node. Is this a file or a AST symbol (e.g. function)?
-    optional Kind kind = 2;
+    Kind kind = 2;
 
     // Name of out-edge symbols. For a program to be considered valid, all
     // symbolic references must be present in the graph.

--- a/program_graph.proto
+++ b/program_graph.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package splitbrain;
+
 // NodeDef represents a node within the program graph.
 //
 // This can be be a file, BUILD target, or AST symbol. Note there is not enough


### PR DESCRIPTION
This change adds a launcher binary to run over an arbitrary program `GraphDef`.
The input can be sourced from Kythe bindings, a BUILD graph or a source file
dependency graph.

Future additions will add generators for those, as well as a statistics module for
counting and evaluating the quality of the algorithms.